### PR TITLE
Render in thread to handle mutable objects correctly

### DIFF
--- a/src/spyscope/core.clj
+++ b/src/spyscope/core.clj
@@ -69,19 +69,18 @@
   "Reader function to store detailed information about a form's value at runtime
   into a trace that can be queried asynchronously."
   [form]
-  `(let [f# ~form]
+  `(let [f# ~form
+         value# (pretty-render-value f#
+                                     ~(assoc (meta form)
+                                        ::form (list 'quote form)))]
      (send-off trace-storage
-           (fn [{g# :generation t# :trace :as storage#}]
-             (let [value# (pretty-render-value
-                            f#
-                            ~(assoc (meta form)
-                                    ::form (list 'quote form)))]
-               (when ~(::print? (meta form))
-                 (println (:message value#)))
-               (assoc storage#
-                      :trace
-                      (conj t# (assoc value#
-                                      :generation g#))))))
+               (fn [{g# :generation t# :trace :as storage#}]
+                 (when ~(::print? (meta form))
+                   (println (:message value#)))
+                 (assoc storage#
+                   :trace
+                   (conj t# (assoc value#
+                              :generation g#)))))
      f#))
 
 (defn print-log-detailed


### PR DESCRIPTION
e.g. when you spy a java.util.List and immediately modify it afterwards, it might be changed before reaching the printing thread.
- minor fixes
