### PR TITLE
Updating dependencies version numbers

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,5 +3,5 @@
   :url "http://github.com/dgrnbrg/spyscope"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.4.0"]
-                 [clj-time "0.5.0"]])
+  :dependencies [[org.clojure/clojure "1.6.0"]
+                 [clj-time "0.7.0"]])


### PR DESCRIPTION
Because of old clj-time version, it was causing conflicts in the project that I was working on, which already had a dependency on `[clj-time 0.6.0]` and hence `lein repl` would die with:

```
Caused by: java.lang.ClassNotFoundException: clj_time.core.DateTimeProtocol
        at java.net.URLClassLoader$1.run(URLClassLoader.java:372)
        at java.net.URLClassLoader$1.run(URLClassLoader.java:361)
        at java.security.AccessController.doPrivileged(Native Method)
        at java.net.URLClassLoader.findClass(URLClassLoader.java:360)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:308)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 183 more
Subprocess failed
```

If I update the clj-time dependency version, then it seems to work fine.
