### PR TITLE
replace clojure.pprint with puget.printer

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,5 +4,6 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :deploy-repositories  [["releases" :clojars]]
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [clj-time "0.7.0"]])
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [clj-time "0.7.0"]
+                 [mvxcvi/puget "1.0.0"]])

--- a/src/spyscope/core.clj
+++ b/src/spyscope/core.clj
@@ -1,6 +1,6 @@
 (ns spyscope.core
   "This co"
-  (require [clojure.pprint :as pp]
+  (require [puget.printer :as pp]
            [clojure.string :as str]
            [clj-time.core :as time]
            [clj-time.format :as fmt]))
@@ -36,7 +36,7 @@
                  
 
         w (java.io.StringWriter.)
-        _ (pp/pprint form w)
+        _ (pp/cprint form w)
         value-string (str w)
 
         ;Strip trailing line break
@@ -73,7 +73,7 @@
 (defn print-log
   "Reader function to pprint a form's value."
   [form]
-  `(doto ~form pp/pprint))
+  `(doto ~form pp/cprint))
 
 (def ^{:internal true} trace-storage (agent {:trace [] :generation 0}))
 


### PR DESCRIPTION
Fairly trivial change. Hopefully Fipp offers performance advantages to this update. Also, the newest version of Fipp appears to require Clojure 1.7.

I investigated colorization for Vim (being my primary editor), however, nothing simple stood out.