### PR TITLE
Fix invalid ns forms

### DIFF
--- a/src/spyscope/core.clj
+++ b/src/spyscope/core.clj
@@ -1,9 +1,9 @@
 (ns spyscope.core
   "This co"
-  (require [puget.printer :as pp]
-           [clojure.string :as str]
-           [clj-time.core :as time]
-           [clj-time.format :as fmt]))
+  (:require [puget.printer :as pp]
+            [clojure.string :as str]
+            [clj-time.core :as time]
+            [clj-time.format :as fmt]))
 
 (defn- indent
   "Indents a string with `n` spaces."

--- a/src/spyscope/repl.clj
+++ b/src/spyscope/repl.clj
@@ -1,7 +1,7 @@
 (ns spyscope.repl
   "This contains the query functions suitable for inspecting traces
   from the repl."
-  (require [clojure.string :as str]) 
+  (:require [clojure.string :as str]) 
   (:use [spyscope.core :only [trace-storage]]))
 
 (defn trace-query


### PR DESCRIPTION
I found this doing some testing with a spec'ed version of the ns macro - while using bare calls like this work in ns, that's not intentional and it should be considered invalid.