### PR TITLE
puget.printer/cprint-str does not have a trailing newline

### DIFF
--- a/src/spyscope/core.clj
+++ b/src/spyscope/core.clj
@@ -35,9 +35,6 @@
 
         value-string (pp/cprint-str form)
 
-        ;Strip trailing line break
-        value-string  (.substring value-string 0 (dec (count value-string)))
-
         ;Are there multiple trace lines?
         multi-trace? (> n 1)
 


### PR DESCRIPTION
`puget.printer/cprint-str` does not have a trailing newline, so removing the last chars messes up the escape codes causing weird output.