### PR TITLE
ClojureScript support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ pom.xml
 .lein-deps-sum
 .lein-failures
 .lein-plugins
+/spyscope.iml
+/.lein-repl-history
+/.idea/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Spyscope
 
-A Clojure library designed to make it easy to debug single- and multi-threaded applications.
+A Clojure(Script) library designed to make it easy to debug single- and multi-threaded applications.
 
 ## Installation
 

--- a/project.clj
+++ b/project.clj
@@ -1,10 +1,41 @@
 (defproject spyscope "0.1.7-SNAPSHOT"
-  :description "Trace-oriented debugging tools for Clojure"
+  :description "Trace-oriented debugging tools for Clojure(Script)"
+
   :url "http://github.com/dgrnbrg/spyscope"
+
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
+
   :deploy-repositories  [["releases" :clojars]]
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [clj-time "0.12.2"]
-                 [mvxcvi/puget "1.0.1"]]
-  :eval-in-leiningen true)
+
+  :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/clojurescript "1.10.238"]
+                 [clj-time "0.14.3"]
+                 [com.andrewmcveigh/cljs-time "0.5.2"]
+                 [net.cgrand/macrovich "0.2.1"]
+                 ;[mvxcvi/puget "1.0.2"]
+                 [mvxcvi/puget "1.0.2" :exclusions [org.clojure/core.rrb-vector]]
+                 [quantum/org.clojure.core.rrb-vector "0.0.12"]]
+
+  :plugins [[lein-cljsbuild "1.1.7"]
+            [lein-doo "0.1.10" :exclusions [org.clojure/clojurescript]]]
+
+  :eval-in-leiningen true
+
+  :profiles
+  {:test {:dependencies [[lein-doo "0.1.10"]]}}
+
+  :doo {:build "test"
+        :source-paths ["src" "test"]
+        :alias {:default [:chrome-headless]}}
+
+  :cljsbuild
+  {:builds
+   [{:id "test"
+     :source-paths ["src" "test"]
+     :compiler
+       {:output-dir "target/cljs/out"
+        :output-to "target/cljs/tests.js"
+        :main spyscope.test-runner
+        :optimizations :whitespace}}]})
+

--- a/project.clj
+++ b/project.clj
@@ -13,9 +13,9 @@
                  [clj-time "0.14.3"]
                  [com.andrewmcveigh/cljs-time "0.5.2"]
                  [net.cgrand/macrovich "0.2.1"]
-                 ;[mvxcvi/puget "1.0.2"]
-                 [mvxcvi/puget "1.0.2" :exclusions [org.clojure/core.rrb-vector]]
-                 [quantum/org.clojure.core.rrb-vector "0.0.12"]]
+                 [mvxcvi/puget "1.0.2" :exclusions [brandonbloom/fipp]]
+                 [bigml/fipp "0.6.8"]]
+
 
   :plugins [[lein-cljsbuild "1.1.7"]
             [lein-doo "0.1.10" :exclusions [org.clojure/clojurescript]]]

--- a/src/data_readers.cljc
+++ b/src/data_readers.cljc
@@ -1,0 +1,3 @@
+{spy/p spyscope.core/print-log
+ spy/d spyscope.core/print-log-detailed
+ spy/t spyscope.core/trace}

--- a/src/spyscope/core.cljc
+++ b/src/spyscope/core.cljc
@@ -1,0 +1,128 @@
+(ns spyscope.core
+  (:require [clojure.string :as str]
+
+            #?(:clj  [clj-time.core :as time]
+               :cljs [cljs-time.core :as time])
+
+            #?(:clj  [clj-time.format :as fmt]
+               :cljs [cljs-time.format :as fmt])
+
+            #?(:clj  [puget.printer :as pp]))
+  #?(:clj  (:require [net.cgrand.macrovich :as macrovich])
+     :cljs (:require-macros [net.cgrand.macrovich :as macrovich])))
+
+
+(defn- indent
+  "Indents a string with `n` spaces."
+  [n string]
+  (let [indent (str/join (repeat n " "))]
+    (->> (str/split string #"\n")
+         (map (partial str indent))
+         (str/join "\n"))))
+
+(defn pretty-render-value
+  "Prints out a form and some extra info for tracing/debugging.
+
+  Prints the last `n` stack frames"
+  [form meta]
+  (let [now (time/now)
+        nses-regex (:nses meta)
+        n (or (:fs meta) 1)
+
+        frames-base #?(:clj  (->> (ex-info "" {})
+                                  .getStackTrace
+                                  seq
+                                  (drop 2))
+                       :cljs (->> (ex-info "" {})
+                                  .-stack
+                                  (str/split-lines)
+                                  (drop 2)
+                                  (drop-while #(str/includes? % "ex_info"))
+                                  (map #(str/replace % "    at " ""))))
+
+        frames (if nses-regex
+                 (filter (comp (partial re-find nses-regex) str)
+                         frames-base)
+                 frames-base)
+
+        frames #?(:clj  (->> frames
+                             (remove #(clojure.string/includes? % "spyscope.core"))
+                             (take n)
+                             (map str)
+                             (reverse))
+                  :cljs (->> frames
+                             (remove #(clojure.string/includes? % "spyscope$core"))
+                             (remove #(not (clojure.string/includes? % "(")))
+                             (take n)
+                             (reverse)))
+
+        value-string #?(:clj  (pp/cprint-str form)
+                        :cljs (str form))
+
+        ;Are there multiple trace lines?
+        multi-trace? (> n 1)
+
+        ;Indent if it's a multi-line structure
+        value-string (if (or (> (count value-string) 40)
+                             (str/includes? value-string "\n"))
+                       (str "\n" (indent 2 value-string))
+                       value-string)
+
+        prefix (str/join "\n" frames)]
+    {:message (str
+                (when multi-trace?
+                  (str (str/join (repeat 40 \-)) \newline))
+                prefix
+                (when-let [time? (:time meta)]
+                  (str " " (fmt/unparse (if (string? time?)
+                                          (fmt/formatter time?)
+                                          (fmt/formatters :date-hour-minute-second))
+                                        now)))
+                (when-let [marker (:marker meta)]
+                  (str " " marker))
+                (when (or (not (contains? meta :form))
+                          (:form meta))
+                  (str " " (pr-str (::form meta))))
+                " => " value-string)
+     :frame1 (str (first frames-base))}))
+
+(defn print-log
+  "Reader function to pprint a form's value."
+  [form]
+  `(macrovich/case
+     :clj  (doto ~form pp/cprint)
+     :cljs (println ~form)))
+
+
+; Trace storage - an atom rather than an agent is used in cljs.
+#?(:clj  (def ^{:internal true} trace-storage (agent {:trace [] :generation 0}))
+   :cljs (def ^{:internal true} trace-storage (atom {:trace [] :generation 0})))
+
+(defn trace
+  "Reader function to store detailed information about a form's value at runtime
+  into a trace that can be queried asynchronously."
+  [form]
+  `(let [f# ~form
+         value# (pretty-render-value f#
+                                     ~(assoc (meta form)
+                                        ::form (list 'quote form)))]
+     (when ~(::print? (meta form))
+       (print (str (:message value#) "\n")))
+     ((macrovich/case :clj send-off :cljs swap!) trace-storage
+               (fn [{g# :generation t# :trace :as storage#}]
+                 (assoc storage#
+                   :trace
+                   (conj t# (assoc value#
+                              :generation g#)))))
+     f#))
+
+
+(defn print-log-detailed
+  "Reader function to pprint a form's value with some extra information."
+  [form]
+  (letfn [(print [m] (assoc m ::print? true))]
+    (->> form
+         meta
+         print
+         (with-meta form)
+         trace)))

--- a/src/spyscope/plugin.cljc
+++ b/src/spyscope/plugin.cljc
@@ -1,0 +1,5 @@
+(ns spyscope.plugin)
+
+(defn middleware [project]
+  (update-in project [:injections] concat
+             `[(spit "resources/project.clj" ~(prn-str project))]))

--- a/src/spyscope/repl.cljc
+++ b/src/spyscope/repl.cljc
@@ -1,0 +1,49 @@
+(ns spyscope.repl
+  "This contains the query functions suitable for inspecting traces
+  from the repl."
+  (:require [clojure.string :as str]) 
+  (:use [spyscope.core :only [trace-storage]]))
+
+(defn trace-query
+  "Prints information about trace results.
+  
+  With no arguments, this prints every trace from the current generation.
+  
+  With one numeric argument `generations`, this prints every trace from the previous
+  `generations` generations.
+  
+  With one regex argument `re`, this prints every trace from the current generation
+  whose first stack frame matches the regex.
+  
+  With two arguments, `re` and `generations`, this matches every trace whose stack frame
+  matches `re` from the previosu `generations` generations."
+  ([]
+   (trace-query #".*" 1))
+  ([re-or-generations]
+   (if (number? re-or-generations)
+     (trace-query #".*" re-or-generations)
+     (trace-query re-or-generations 1)))
+  ([re generations]
+   (let [{:keys [generation trace]} @trace-storage
+         generation-min (- generation generations)]
+     (->> trace
+       (filter #(re-find re (:frame1 %)))
+       (filter #(> (:generation %) generation-min))
+       (map :message)
+       (interpose (str/join (repeat 40 "-")))
+       (str/join "\n")
+       (println)))))
+
+(defn trace-next
+  "Increments the generation of future traces."
+  []
+  #?(:clj (send trace-storage update-in [:generation] inc)
+     :cljs (swap! trace-storage update-in [:generation] inc))
+  nil)
+
+(defn trace-clear
+  "Deletes all trace data so far (used to reduce memory consumption)"
+  []
+  #?(:clj (send trace-storage (fn [_] {:trace [] :generation 0}))
+     :cljs (swap! trace-storage (fn [_] {:trace [] :generation 0})))
+  nil)

--- a/test/spyscope/test_runner.cljs
+++ b/test/spyscope/test_runner.cljs
@@ -1,0 +1,5 @@
+(ns spyscope.test-runner
+  (:require [doo.runner :refer-macros [doo-tests]]
+            [spyscope.tests]))
+
+(doo-tests 'spyscope.tests)

--- a/test/spyscope/tests.clj
+++ b/test/spyscope/tests.clj
@@ -1,0 +1,28 @@
+(ns spyscope.tests
+  (:require [clojure.test :refer :all]
+            [puget.printer :as puget]
+            [clojure.string :as str]
+            [spyscope.core]
+            [spyscope.repl]))
+
+(set! *data-readers*
+  {'spy/p spyscope.core/print-log
+   'spy/d spyscope.core/print-log-detailed
+   'spy/t spyscope.core/trace})
+
+(deftest print-log-test
+  (is (= (str (puget/cprint-str 6) "\n")
+         (with-out-str #spy/p (+ 1 2 3)))))
+
+(deftest print-log-detailed-test
+  (is (re-matches #"(?s)spyscope\.tests.*\.invoke\(tests\.clj:.*\) \(\+ 1 2 3\) => .*"
+                  (with-out-str #spy/d (+ 1 2 3))))
+  (is (str/ends-with? (with-out-str #spy/d (+ 1 2 3))
+                      (str (puget/cprint-str 6) "\n"))))
+
+(deftest trace-test
+  #spy/t (* 1 2 3)
+  (is (re-matches #"(?s)spyscope\.tests.*\.invokeStatic\(tests\.clj:.*\) \(\* 1 2 3\) => .*"
+                  (with-out-str (spyscope.repl/trace-query))))
+  (is (str/ends-with? (with-out-str (spyscope.repl/trace-query))
+                      (str (puget/cprint-str 6) "\n"))))

--- a/test/spyscope/tests.cljs
+++ b/test/spyscope/tests.cljs
@@ -1,0 +1,19 @@
+(ns spyscope.tests
+  (:require [cljs.test :refer-macros [deftest is]]
+            [spyscope.core]
+            [spyscope.repl]))
+
+(deftest print-log-test
+  (is (= "6\n"
+         (with-out-str #spy/p (+ 1 2 3)))))
+
+(deftest print-log-detailed-test
+  (spyscope.repl/trace-clear)
+  (is (re-matches #"spyscope\.tests\.print_log_detailed_test\.cljs.*\(\+ 1 2 3\) => 6\n"
+                  (with-out-str #spy/d (+ 1 2 3)))))
+
+(deftest trace-test
+  (spyscope.repl/trace-clear)
+  #spy/t (* 1 2 3)
+  (is (re-matches #"spyscope\.tests\.trace_test\.cljs.*\(\* 1 2 3\) => 6\n"
+                  (with-out-str (spyscope.repl/trace-query)))))

--- a/test/spyscope/tests.cljs
+++ b/test/spyscope/tests.cljs
@@ -9,7 +9,7 @@
 
 (deftest print-log-detailed-test
   (spyscope.repl/trace-clear)
-  (is (re-matches #"spyscope\.tests\.print_log_detailed_test\.cljs.*\(\+ 1 2 3\) => 6\n"
+  (is (re-matches #"spyscope\.tests\.print_log_detailed_test\.cljs.*\(\+ 1 2 3\) => 6"
                   (with-out-str #spy/d (+ 1 2 3)))))
 
 (deftest trace-test


### PR DESCRIPTION
**Modifications for ClojureScript support**
- Renamed source files to .cljc
- Added cljs printing support for #spy/p, #spy/d and #spy/t
- Atom used for trace storage in cljs (agents not supported) 
- Added clj and cljs unit tests. Cljs unit testing supported with doo
- Macrovich library used in macros to determine target environment at macro expansion

**Issues**
- No colorized/pretty printing support in cljs yet.  This can be added later if https://github.com/greglook/puget/issues/27 is resolved
- Had to swap out fipp dependency with fixed version for cljs issue: see https://dev.clojure.org/jira/browse/CRRBV-15 and https://github.com/brandonbloom/fipp/issues/42